### PR TITLE
Ensure the CSV file is always closed correctly

### DIFF
--- a/src/ofxstatement/plugins/germany_1822direkt.py
+++ b/src/ofxstatement/plugins/germany_1822direkt.py
@@ -8,8 +8,9 @@ from ofxstatement.statement import StatementLine
 class FrankfurterSparkasse1822Plugin(Plugin):
     def get_parser(self, filename):
         encoding = self.settings.get('charset', 'iso-8859-1')
-        f = open(filename, 'r', encoding=encoding)
-        parser = FrankfurterSparkasse1822Parser(f)
+        with open(filename, 'r', encoding=encoding) as f:
+            lines = f.readlines()
+        parser = FrankfurterSparkasse1822Parser(lines)
         parser.statement.account_id = self.settings['account']
         parser.statement.bank_id = self.settings.get('bank', '50050201')
         parser.statement.currency = self.settings.get('currency', 'EUR')


### PR DESCRIPTION
Since currently this is not possible when using a file as parameter (see
https://github.com/kedder/ofxstatement/issues/71) the easiest workaround
is to simply pass the file content to the parser. The csv.reader() takes
any iterable (such as a list of lines, as in this case) as input.